### PR TITLE
Remove Chrome Frame from X-UA-Compatible HTTP header as it's deprecated

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ There's a frood who really knows where his towel is.
 1.0b5 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Remove Chrome Frame from ``X-UA-Compatible`` HTTP header as it's deprecated.
+  [hvelarde]
+
 - Allow use of percent sign (%) on width properties (closes `#6`_).
   [rodfersou, hvelarde]
 

--- a/src/sc/embedder/content/templates/embeddervideojs.pt
+++ b/src/sc/embedder/content/templates/embeddervideojs.pt
@@ -13,7 +13,7 @@
         site_properties context/portal_properties/site_properties;
         ajax_load request/ajax_load | nothing;
         ajax_include_head request/ajax_include_head | nothing;
-        dummy python:request.RESPONSE.setHeader('X-UA-Compatible', 'IE=edge,chrome=1');"
+        dummy python:request.RESPONSE.setHeader('X-UA-Compatible', 'IE=edge');"
     tal:attributes="lang lang;">
 
     <metal:cache use-macro="context/global_cache_settings/macros/cacheheaders">


### PR DESCRIPTION
See: https://blog.chromium.org/2013/06/retiring-chrome-frame.html